### PR TITLE
Do not throw out players when world visiting

### DIFF
--- a/Service/FinderService.cs
+++ b/Service/FinderService.cs
@@ -138,8 +138,6 @@ namespace MiniMappingway.Service
                 // ignored
             }
 
-            //Parallel.For(1, ServiceManager.ObjectTable.Length, (i, state) =>
-
             var alreadyInFriendBag = false;
             var alreadyInFcBag = false;
             var obj = ServiceManager.ObjectTable[i];
@@ -206,15 +204,15 @@ namespace MiniMappingway.Service
                 }
                 var tempFc = new ReadOnlySpan<byte>(charPointer->FreeCompanyTag, 7);
                 var playerFc = new ReadOnlySpan<byte>(fc, 7);
-                if (playerFc.SequenceEqual(tempFc) && fc->CompareTo(0) != 0)
+                if (fc->CompareTo(0) != 0)
                 {
+                    if (playerFc.SequenceEqual(tempFc))
+                    {
 
-                    var personDetails = new PersonDetails(obj.Name.ToString(), obj.ObjectId, FcMembersKey, obj.Address);
-                    alreadyInFcBag = true;
-                    ServiceManager.NaviMapManager.AddToBag(personDetails);
-                    
-
-
+                        var personDetails = new PersonDetails(obj.Name.ToString(), obj.ObjectId, FcMembersKey, obj.Address);
+                        alreadyInFcBag = true;
+                        ServiceManager.NaviMapManager.AddToBag(personDetails);
+                    }
                 }
             }
 

--- a/Service/FinderService.cs
+++ b/Service/FinderService.cs
@@ -206,11 +206,7 @@ namespace MiniMappingway.Service
                 }
                 var tempFc = new ReadOnlySpan<byte>(charPointer->FreeCompanyTag, 7);
                 var playerFc = new ReadOnlySpan<byte>(fc, 7);
-                if (fc->CompareTo(0) == 0)
-                {
-                    return;
-                }
-                if (playerFc.SequenceEqual(tempFc))
+                if (playerFc.SequenceEqual(tempFc) && fc->CompareTo(0) != 0)
                 {
 
                     var personDetails = new PersonDetails(obj.Name.ToString(), obj.ObjectId, FcMembersKey, obj.Address);


### PR DESCRIPTION
I didn't exactly know what this operation was calculating, but it was responsible for preventing PCs from being added to the Everyone section of the bag when the PC was world visiting.
So, I have removed it from issuing a return from the function, but now it is a part of the check for requirements of the FC bag.