### PR TITLE
Adjust Visible flag check

### DIFF
--- a/Manager/NaviMapManager.cs
+++ b/Manager/NaviMapManager.cs
@@ -156,7 +156,7 @@ namespace MiniMappingway.Manager
             X = NaviMapPointer->X;
             Y = NaviMapPointer->Y;
             NaviScale = NaviMapPointer->Scale;
-            Visible = (NaviMapPointer->VisibilityFlags & 0x03) == 0;
+            Visible = (NaviMapPointer->IsVisible && NaviMapPointer->VisibilityFlags == 0);
             return true;
         }
 


### PR DESCRIPTION
I referenced this in #17, however I believe I had extra code that was managing this as now I cannot replicate the function with the short sample I supplied. Having discarded that code entirely by accident, I have had to deal with making a new solution to this problem.
I can't be very technical with this, the bitwise operation does things, but since I don't know what each flag is meant to represent, I've had to fly blind on this with the Data display.

Currently, the plugin will continue to render when the map is visible in some (but not all?) cutscenes. This might be more to do with the player being in an instanced area rather than a public space while doing so. It will also render when the minimap is toggled to be invisible on the hudlayout, this adds some complications I will explain.

Using `/mmwaydebug` allows us to give a state of whether anything will render or not, so it provides as a good test
Here we can see that on this layout, the minimap is visible by it's visibility flag of `0` as well as the bool `IsVisible` of True
![image](https://user-images.githubusercontent.com/12771982/214065771-84c84752-3e76-4b64-9549-7f5abd13fc5c.png)

However, for some reason to do with the upstream library into dalamud's clientstructs, when we hide the item from the layout, it's `IsVisible` state is still True, while the flag has been set to `1`
![image](https://user-images.githubusercontent.com/12771982/214067847-f52e34a2-7891-486d-a446-9245b85eeaf6.png)

The catch-22 of this is that even in cutscenes, the visibility flag is still set to `0`, while `IsVisible` is False, however while testing I wasn't able to get it visible even when using the addon inspector to force it back on
![image](https://user-images.githubusercontent.com/12771982/214069781-043dc221-c064-475c-9112-e109372ad158.png)


Even if this could be further improved with a better understanding of flags, I believe it's already in a state of being a significant improvement to this problem
![23-01-24_01-44-26-FINAL_FANTASY_XIV](https://user-images.githubusercontent.com/12771982/214068507-e6f4ff0d-7e91-42db-978f-ac0f5b09842e.gif)
-
This would also fix #15 